### PR TITLE
Redesign account page, fix en font fallback and records dark-mode readability

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -150,6 +150,7 @@ components:
 - **Display**（`.type-hero-display`，3rem，md 6rem，700）：首頁 hero 專用。
 - **Headline**（`.type-page-title`，1.5rem，700，main 色）：頁面標題。
 - **Title**（`.type-section-title` / `.type-subsection-title`，1.25rem，700，main 色）：區塊與子區塊標題。
+- **Identity**（`.type-identity`，1.5rem，700，foreground 色）：使用者名稱等身分標識（如 account 頁）。
 - **Modal Display**（`.type-modal-display`，1.875rem，md 3rem）：modal 內的卡片大標。
 - **Body**（`.type-body` 1rem / `.type-body-lg` 1.125rem / `.type-body-sm` 0.875rem）：內文三階。
 - **Label**（`.type-caption`，0.75rem）：註解、輔助文字。

--- a/handoff-ui-audit.md
+++ b/handoff-ui-audit.md
@@ -1,0 +1,51 @@
+# Handoff: 全站 UI 巡檢與顏色可讀性修復
+
+日期：2026-06-11｜分支：`improvement`｜接續者請先讀 `CLAUDE.md`、`.project/style.md`、`DESIGN.md`
+
+## 任務背景
+
+使用 Claude in Chrome 對 localhost:3000（dev server）做全站巡檢：所有頁面、亮暗兩種模式、表格頁，並實際提交多份心情日記驗證 explore 流程。找到的錯誤與顏色可讀性問題直接修復。
+
+## 已完成
+
+### 巡檢範圍（全部通過，除下列修復項）
+
+- 公開頁：首頁、about-emotions、emo-cards（含分類頁、卡片 modal、情緒表 chip 檢視），zh-TW / en / ja 三語首頁
+- 登入頁：explore 全流程、records 表格、record 詳細/編輯、analysis 圖表、account
+- 實測提交 2 份心情日記（正面情緒走亮色、負面情緒走暗色），編輯後重存也正常
+- Console 無錯誤；`pnpm lint` 通過（3 個既有 warning：useProfileForm.ts、records-actions.ts 的 unused imports，與本次無關）
+
+### 修復（未 commit，working tree 上）
+
+兩個檔案，`git diff` 可看全部細節：
+
+1. `src/components/records/RecordsList.tsx`
+   - 暗色斑馬紋：`bg-main-tint03/30` 疊深底變中灰、teal 字看不清 → 加 `dark:bg-main/10`、`dark:hover:bg-main/20`
+   - `border-gray-200 dark:border-gray-700` → `border-border`；placeholder 與分隔點改 `text-muted-foreground`
+2. `src/components/records/RecordAnalysis.tsx`
+   - 長條圖 X 軸線寫死 `#343a40`，暗色看不見 → 軸線與刻度改 `currentColor`（移除 `CHART_AXIS_STROKE` 常數）
+   - 圓餅圖標籤原用類別色當文字色（亮色下黃字白底不可讀）→ 自訂 label `<text>` 用 `currentColor`
+   - 兩張圖 Tooltip 的類組名稱原本染資料色（白底淡黃字幾乎隱形）→ 加 `labelStyle` / `itemStyle` 固定 `var(--color-gray-800)`（tooltip 底色為 recharts 預設白）
+
+全部修復已在 Chrome 亮暗兩模式重新驗證過。
+
+## 已知未處理事項（下個 session 可接手）
+
+1. **未 commit**：上述 2 檔案的修改待使用者確認後提交。
+2. `/en`、`/ja` 直接輸入網址會被 locale cookie 導回 `/zh-TW`（proxy 設計：cookie 優先）。透過 header 語言切換器運作正常。判斷為 intended，未動 `src/proxy.ts`，若要改行為需與使用者確認。
+3. emo-cards 頁的「展開」按鈕在預設狀態顯示為灰底（active/disabled 樣式），與「收合」「情緒表」外觀不一致，輕微，未改。
+4. 測試資料：DB 裡新增了 2 筆 2026-06-11 的 emotion_records（內容為測試用日記），未刪除。
+5. 既有大量 `gray-* dark:gray-*` 手動配對（MobileNav、Footer、StoryTextarea、ThemeToggle 等，grep `dark:` 可列出）。巡檢時視覺上皆可讀，故未重構；若要全面 token 化是獨立工作。
+
+## 環境備忘
+
+- dev server 由使用者啟動於 :3000，勿用 preview_* 工具，使用者指定用 Claude in Chrome MCP 驗證
+- 已登入狀態（WorkOS），帳號 Leon Wu；主題切換鈕在 header 右上、語言切換在其左
+- 分析頁需按「分析」按鈕才會出圖；日期格式 DD/MM/YYYY
+- recharts tooltip/label 的 SVG attribute 不吃 CSS var，但 `currentColor` 可以；style object 內可用 CSS var
+
+## 建議下個 session 使用的 skills
+
+- `/code-review`（low/medium）：commit 前看一下這兩個檔案的 diff
+- `verify` 或 `run`：若再做 UI 修改需回歸驗證（注意：本專案使用者偏好 Chrome MCP 而非 preview 工具）
+- `impeccable`：若要繼續做整體 UI 打磨（如第 3、5 點）

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -218,6 +218,11 @@ h3 {
   color: var(--color-main);
 }
 
+.type-identity {
+  font-size: var(--type-h2);
+  font-weight: 700;
+}
+
 .type-body-lg {
   font-size: var(--type-h4);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,9 +92,16 @@ export default async function RootLayout({
   const locale = await getRequestLocale();
   const messages = await getMessages();
 
+  // Font variables live on <html> so the :lang() font-family rules in
+  // globals.css can resolve them; on <body> they are invisible to the
+  // root element and the whole chain collapses to the browser default.
   return (
-    <html lang={locale} suppressHydrationWarning>
-      <body className={`${inter.variable} ${notoSansTC.variable} ${notoSansJP.variable} font-sans antialiased overflow-x-hidden`}>
+    <html
+      lang={locale}
+      suppressHydrationWarning
+      className={`${inter.variable} ${notoSansTC.variable} ${notoSansJP.variable}`}
+    >
+      <body className="font-sans antialiased overflow-x-hidden">
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <ThemeSyncer userId={user?.id ?? null} />

--- a/src/components/account/AccountProfile.tsx
+++ b/src/components/account/AccountProfile.tsx
@@ -45,11 +45,24 @@ export function AccountProfile({ initialProfile, email }: AccountProfileProps) {
     handleSave,
   } = useProfileForm({ initialProfile, t });
 
+  const lastName = profile.last_name?.trim() ?? '';
+  const firstName = profile.first_name?.trim() ?? '';
+  // CJK names follow the locale's order (e.g. 姓+名 without a space);
+  // purely Latin names always read as "First Last".
+  const hasCjkName = /[぀-ヿ㐀-鿿豈-﫿]/.test(lastName + firstName);
+  const displayName =
+    lastName || firstName
+      ? hasCjkName
+        ? t('nameDisplay', { lastName, firstName }).trim()
+        : [firstName, lastName].filter(Boolean).join(' ')
+      : '';
+
   return (
     <>
-      {/* Sticky title bar */}
+      {/* Sticky title bar — constrained to the content column so the title,
+          actions and underline align with the fields below. */}
       <div className={`sticky ${AUTH_STICKY_TOP} z-30 pb-2 bg-background px-3 sm:px-0`}>
-        <div className="container mx-auto pt-4">
+        <div className="max-w-2xl mx-auto pt-4">
           <div className="pb-2 border-b-2 border-main-tint02 flex justify-between items-center gap-2">
             <h2>{t('title')}</h2>
 
@@ -86,43 +99,28 @@ export function AccountProfile({ initialProfile, email }: AccountProfileProps) {
       </div>
 
       {/* Content */}
-      <div className="grow px-3 sm:px-0 flex flex-col items-center pt-6">
-        <div className="w-full max-w-2xl px-3 sm:px-0">
-          {/* Illustration */}
-          <div className="flex flex-col items-center mb-6">
+      <div className="grow px-3 sm:px-0 flex flex-col items-center pt-8 pb-16">
+        <div className="w-full max-w-2xl">
+          {/* Identity header */}
+          <div className="mb-10 flex items-center justify-between gap-6">
+            <div className="min-w-0">
+              <p className="type-identity break-words">{displayName || email}</p>
+              {displayName && (
+                <p className="type-body-sm mt-1 break-all text-muted-foreground">{email}</p>
+              )}
+            </div>
             <Image
               src="/images/account_illu.svg"
-              alt="Account illustration"
+              alt=""
               width={180}
               height={180}
-              className="w-36 sm:w-44"
+              className="w-24 sm:w-32 shrink-0"
               priority
             />
-            <p className="type-caption mt-2 text-gray-500 dark:text-gray-400">
-              Illustration by{' '}
-              <a
-                className="hover:text-main underline"
-                href="https://icons8.com/illustrations/author/iAdLsFJOKDrk"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Tanya Krasutska
-              </a>{' '}
-              from{' '}
-              <a
-                className="hover:text-main underline"
-                href="https://icons8.com/illustrations"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Ouch!
-              </a>
-            </p>
           </div>
 
           {/* Profile fields */}
           <ProfileFormFields
-            email={email}
             profile={profile}
             isEditing={isEditing}
             formLastName={formLastName}
@@ -138,6 +136,28 @@ export function AccountProfile({ initialProfile, email }: AccountProfileProps) {
             validateLastName={validateLastName}
             validateFirstName={validateFirstName}
           />
+
+          {/* Illustration attribution */}
+          <p className="type-caption mt-14 text-center text-muted-foreground">
+            Illustration by{' '}
+            <a
+              className="hover:text-main underline"
+              href="https://icons8.com/illustrations/author/iAdLsFJOKDrk"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Tanya Krasutska
+            </a>{' '}
+            from{' '}
+            <a
+              className="hover:text-main underline"
+              href="https://icons8.com/illustrations"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ouch!
+            </a>
+          </p>
         </div>
       </div>
 

--- a/src/components/account/ProfileFormFields.tsx
+++ b/src/components/account/ProfileFormFields.tsx
@@ -3,8 +3,12 @@
 import { useTranslations } from 'next-intl';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { AuthNavigationButton } from '@/components/auth/AuthNavigationButton';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { buildAuthHref, buildCurrentReturnTo } from '@/lib/auth-routing';
 import type { Profile } from '@/types/database';
+
+const KNOWN_TITLES = ['Student', 'Teacher'];
 
 function getTitleDisplay(title: string | null, t: (key: string) => string): string {
   switch (title) {
@@ -17,8 +21,24 @@ function getTitleDisplay(title: string | null, t: (key: string) => string): stri
   }
 }
 
+const sectionTitleClassName = 'type-subsection-title mb-4 border-b-2 border-main-tint02 px-2 py-1';
+const labelClassName = 'type-body-sm block mb-1.5 px-1 text-muted-foreground';
+// View value and edit input share the same pill geometry so toggling
+// edit mode only changes the surface, never the layout.
+const valuePillClassName =
+  'type-body w-full px-5 py-2 rounded-full border-2 border-transparent bg-muted';
+const inputPillClassName =
+  'type-body w-full px-5 py-2 rounded-full border-2 border-input bg-background focus:outline-none focus:border-main transition-colors';
+
+function ValuePill({ value, fallback }: { value: string | null; fallback: string }) {
+  return (
+    <p className={cn(valuePillClassName, !value && 'text-muted-foreground')}>
+      {value || fallback}
+    </p>
+  );
+}
+
 interface ProfileFormFieldsProps {
-  email: string;
   profile: Profile;
   isEditing: boolean;
   // Form fields
@@ -38,7 +58,6 @@ interface ProfileFormFieldsProps {
 }
 
 export function ProfileFormFields({
-  email,
   profile,
   isEditing,
   formLastName,
@@ -62,112 +81,115 @@ export function ProfileFormFields({
     force: true,
   });
 
+  const notAvailable = t('empty.notAvailable');
+
   return (
     <div className="w-full flex-1">
-      {/* Email - always read only */}
-      <div className="mb-6">
-        <span className="type-body-sm block mb-2 text-foreground">{t('fields.email')}</span>
-        <p className="type-body ml-1 font-bold">{email}</p>
-      </div>
+      {/* Personal details */}
+      <section>
+        <div className={sectionTitleClassName}>{t('sections.personal')}</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5">
+          {/* Last Name */}
+          <div>
+            <span className={labelClassName}>{t('fields.lastName')}</span>
+            {isEditing ? (
+              <div>
+                <input
+                  type="text"
+                  className={inputPillClassName}
+                  value={formLastName}
+                  onChange={(e) => {
+                    setFormLastName(e.target.value);
+                    validateLastName(e.target.value);
+                  }}
+                  placeholder={t('placeholders.lastName')}
+                />
+                {lastNameError && (
+                  <p className="type-caption mt-1 ml-3 text-pink">{lastNameError}</p>
+                )}
+              </div>
+            ) : (
+              <ValuePill value={profile.last_name} fallback={notAvailable} />
+            )}
+          </div>
 
-      {/* Password */}
-      <div className="mb-6">
-        <span className="type-body-sm block mb-2 text-foreground">{t('fields.password')}</span>
-        <div className="flex justify-between items-center">
-          <p className="type-body ml-1 font-bold">{t('passwordMask')}</p>
-          {!isEditing && (
-            <AuthNavigationButton
-              href={passwordResetHref}
-              className="type-button px-4 py-1 rounded-full bg-pink-tint01 text-white hover:bg-pink transition-colors"
-            >
-              {t('resetPassword')}
-            </AuthNavigationButton>
-          )}
-        </div>
-      </div>
+          {/* First Name */}
+          <div>
+            <span className={labelClassName}>{t('fields.firstName')}</span>
+            {isEditing ? (
+              <div>
+                <input
+                  type="text"
+                  className={inputPillClassName}
+                  value={formFirstName}
+                  onChange={(e) => {
+                    setFormFirstName(e.target.value);
+                    validateFirstName(e.target.value);
+                  }}
+                  placeholder={t('placeholders.firstName')}
+                />
+                {firstNameError && (
+                  <p className="type-caption mt-1 ml-3 text-pink">{firstNameError}</p>
+                )}
+              </div>
+            ) : (
+              <ValuePill value={profile.first_name} fallback={notAvailable} />
+            )}
+          </div>
 
-      {/* Last Name & First Name */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-0">
-        {/* Last Name */}
-        <div className="mb-6">
-          <span className="type-body-sm block mb-2 text-foreground">{t('fields.lastName')}</span>
-          {isEditing ? (
-            <div>
+          {/* Birthday */}
+          <div>
+            <span className={labelClassName}>{t('fields.birthDate')}</span>
+            {isEditing ? (
               <input
-                type="text"
-                className="type-body w-full px-5 py-2 border-2 border-input rounded-full bg-background focus:outline-none focus:border-main transition-colors"
-                value={formLastName}
-                onChange={(e) => {
-                  setFormLastName(e.target.value);
-                  validateLastName(e.target.value);
-                }}
-                placeholder={t('placeholders.lastName')}
+                type="date"
+                className={inputPillClassName}
+                value={formBirthday}
+                onChange={(e) => setFormBirthday(e.target.value)}
               />
-              {lastNameError && <p className="type-caption mt-1 ml-3 text-pink">{lastNameError}</p>}
-            </div>
-          ) : (
-            <p className="type-body ml-1 font-bold">{profile.last_name || t('empty.notAvailable')}</p>
-          )}
-        </div>
+            ) : (
+              <ValuePill value={profile.day_of_birth} fallback={notAvailable} />
+            )}
+          </div>
 
-        {/* First Name */}
-        <div className="mb-6">
-          <span className="type-body-sm block mb-2 text-foreground">{t('fields.firstName')}</span>
-          {isEditing ? (
-            <div>
-              <input
-                type="text"
-                className="type-body w-full px-5 py-2 border-2 border-input rounded-full bg-background focus:outline-none focus:border-main transition-colors"
-                value={formFirstName}
-                onChange={(e) => {
-                  setFormFirstName(e.target.value);
-                  validateFirstName(e.target.value);
-                }}
-                placeholder={t('placeholders.firstName')}
-              />
-              {firstNameError && <p className="type-caption mt-1 ml-3 text-pink">{firstNameError}</p>}
-            </div>
-          ) : (
-            <p className="type-body ml-1 font-bold">{profile.first_name || t('empty.notAvailable')}</p>
-          )}
+          {/* Title (身份) */}
+          <div>
+            <span className={labelClassName}>{t('fields.role')}</span>
+            {isEditing ? (
+              <select
+                className={inputPillClassName}
+                value={KNOWN_TITLES.includes(formTitle) ? formTitle : 'Null'}
+                onChange={(e) => setFormTitle(e.target.value)}
+              >
+                <option value="Student">{t('options.student')}</option>
+                <option value="Teacher">{t('options.teacher')}</option>
+                <option value="Null">{t('options.other')}</option>
+              </select>
+            ) : (
+              <ValuePill value={getTitleDisplay(profile.title, t)} fallback={notAvailable} />
+            )}
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Birthday & Title */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-0">
-        {/* Birthday */}
-        <div className="mb-6">
-          <span className="type-body-sm block mb-2 text-foreground">{t('fields.birthDate')}</span>
-          {isEditing ? (
-            <input
-              type="date"
-              className="type-body w-full px-5 py-2 border-2 border-input rounded-full bg-background focus:outline-none focus:border-main transition-colors"
-              value={formBirthday}
-              onChange={(e) => setFormBirthday(e.target.value)}
-            />
-          ) : (
-            <p className="type-body ml-1 font-bold">{profile.day_of_birth || t('empty.notAvailable')}</p>
-          )}
+      {/* Password & security */}
+      <section className="mt-10">
+        <div className={sectionTitleClassName}>{t('sections.security')}</div>
+        <div>
+          <span className={labelClassName}>{t('fields.password')}</span>
+          <div className="flex items-center gap-3">
+            <p className={cn(valuePillClassName, 'flex-1 min-w-0')}>{t('passwordMask')}</p>
+            {!isEditing && (
+              <AuthNavigationButton
+                href={passwordResetHref}
+                className={cn(buttonVariants({ variant: 'main-outline' }), 'shrink-0')}
+              >
+                {t('resetPassword')}
+              </AuthNavigationButton>
+            )}
+          </div>
         </div>
-
-        {/* Title (身份) */}
-        <div className="mb-6">
-          <span className="type-body-sm block mb-2 text-foreground">{t('fields.role')}</span>
-          {isEditing ? (
-            <select
-              className="type-body w-full px-5 py-2 border-2 border-input rounded-full bg-background focus:outline-none focus:border-main transition-colors"
-              value={formTitle}
-              onChange={(e) => setFormTitle(e.target.value)}
-            >
-              <option value="Student">{t('options.student')}</option>
-              <option value="Teacher">{t('options.teacher')}</option>
-              <option value="Null">{t('options.other')}</option>
-            </select>
-          ) : (
-            <p className="type-body ml-1 font-bold">{getTitleDisplay(profile.title, t)}</p>
-          )}
-        </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/components/records/RecordAnalysis.tsx
+++ b/src/components/records/RecordAnalysis.tsx
@@ -33,8 +33,7 @@ interface EmotionCategorySummary {
 }
 
 // Chart strokes are SVG attributes and cannot take CSS variables;
-// values mirror the gray ramp in globals.css.
-const CHART_AXIS_STROKE = '#343a40'; // gray-800
+// gray-500 stays legible on both light and dark backgrounds.
 const CHART_LABEL_LINE_STROKE = '#adb5bd'; // gray-500
 
 interface ChartData {
@@ -213,13 +212,13 @@ export function RecordAnalysis({ categories }: RecordAnalysisProps) {
                   <CartesianGrid strokeDasharray="3 3" vertical={false} />
                   <XAxis
                     dataKey="name"
-                    tick={{ fontSize: 'var(--type-body-sm)', fontWeight: 700 }}
-                    axisLine={{ stroke: CHART_AXIS_STROKE, strokeWidth: 2 }}
+                    tick={{ fontSize: 'var(--type-body-sm)', fontWeight: 700, fill: 'currentColor' }}
+                    axisLine={{ stroke: 'currentColor', strokeWidth: 2 }}
                     tickLine={false}
                   />
                   <YAxis
                     allowDecimals={false}
-                    tick={{ fontSize: 'var(--type-body-sm)' }}
+                    tick={{ fontSize: 'var(--type-body-sm)', fill: 'currentColor' }}
                     axisLine={false}
                     tickLine={false}
                     label={{ value: t('charts.frequency.unit'), position: 'top', offset: 10, style: { fontSize: 'var(--type-caption)', fill: 'var(--color-gray-600)' } }}
@@ -229,6 +228,8 @@ export function RecordAnalysis({ categories }: RecordAnalysisProps) {
                     separator=""
                     labelFormatter={(label) => String(label)}
                     contentStyle={{ borderRadius: '8px', border: '1px solid var(--border)' }}
+                    labelStyle={{ color: 'var(--color-gray-800)' }}
+                    itemStyle={{ color: 'var(--color-gray-800)' }}
                   />
                   <Bar dataKey="count" radius={[50, 50, 0, 0]} barSize={28}>
                     {chartData.map((entry, index) => (
@@ -263,7 +264,18 @@ export function RecordAnalysis({ categories }: RecordAnalysisProps) {
                     innerRadius="50%"
                     outerRadius="80%"
                     paddingAngle={2}
-                    label={({ name, payload }) => `${name} ${payload?.percentage ?? ''}%`}
+                    label={({ x, y, textAnchor, name, payload }) => (
+                      <text
+                        x={x}
+                        y={y}
+                        textAnchor={textAnchor}
+                        dominantBaseline="central"
+                        fill="currentColor"
+                        style={{ fontSize: 'var(--type-body-sm)' }}
+                      >
+                        {`${name} ${payload?.percentage ?? ''}%`}
+                      </text>
+                    )}
                     labelLine={{ stroke: CHART_LABEL_LINE_STROKE, strokeWidth: 1 }}
                   >
                     {chartData.map((entry, index) => (
@@ -274,6 +286,8 @@ export function RecordAnalysis({ categories }: RecordAnalysisProps) {
                     formatter={(value) => [t('charts.ratio.tooltipValue', { value: String(value) }), '']}
                     separator=""
                     contentStyle={{ borderRadius: '8px', border: '1px solid var(--border)' }}
+                    labelStyle={{ color: 'var(--color-gray-800)' }}
+                    itemStyle={{ color: 'var(--color-gray-800)' }}
                   />
                   <Legend
                     verticalAlign="bottom"

--- a/src/components/records/RecordsList.tsx
+++ b/src/components/records/RecordsList.tsx
@@ -288,7 +288,7 @@ export function RecordsList() {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-main-tint01" />
               <input
                 type="search"
-                className="type-button w-full pl-9 pr-4 py-2.5 border-2 border-main-tint02 rounded-full bg-background placeholder:text-gray-400 dark:placeholder:text-gray-500"
+                className="type-button w-full pl-9 pr-4 py-2.5 border-2 border-main-tint02 rounded-full bg-background placeholder:text-muted-foreground"
                 placeholder={t('search.keywordPlaceholder')}
                 value={keyword}
                 onChange={handleKeywordChange}
@@ -347,8 +347,8 @@ export function RecordsList() {
                     <tr
                       key={record.id}
                       onClick={() => router.push(`/records/${record.id}`)}
-                      className={`text-center border-b border-gray-200 dark:border-gray-700 hover:bg-main-tint03/50 transition-colors cursor-pointer ${
-                        index % 2 !== 0 ? 'bg-main-tint03/30' : ''
+                      className={`text-center border-b border-border hover:bg-main-tint03/50 dark:hover:bg-main/20 transition-colors cursor-pointer ${
+                        index % 2 !== 0 ? 'bg-main-tint03/30 dark:bg-main/10' : ''
                       }`}
                     >
                       <td className="py-3 px-3" onClick={(e) => e.stopPropagation()}>
@@ -366,7 +366,7 @@ export function RecordsList() {
                         <div className="flex flex-row flex-wrap items-center justify-center gap-1">
                           {emotions.map((emo, i) => (
                             <span key={i}>
-                              {i > 0 && <span className="text-gray-400">・</span>}
+                              {i > 0 && <span className="text-muted-foreground">・</span>}
                               {emo.name} {emo.level}
                             </span>
                           ))}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -680,7 +680,12 @@
         "notAvailable": "—"
       },
       "passwordMask": "**********",
-      "resetPassword": "reset password",
+      "resetPassword": "Reset password",
+      "nameDisplay": "{firstName} {lastName}",
+      "sections": {
+        "personal": "Personal details",
+        "security": "Password & security"
+      },
       "confirmCancel": {
         "title": "Are you sure you want to cancel editing?",
         "description": "After canceling the edit, your changes will not be saved. Are you sure you want to cancel the edit?",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -680,7 +680,12 @@
         "notAvailable": "—"
       },
       "passwordMask": "**********",
-      "resetPassword": "パスワードをリセットする",
+      "resetPassword": "パスワードをリセット",
+      "nameDisplay": "{lastName} {firstName}",
+      "sections": {
+        "personal": "プロフィール",
+        "security": "パスワードとセキュリティ"
+      },
       "confirmCancel": {
         "title": "編集をキャンセルしてもよろしいですか?",
         "description": "編集をキャンセルすると、変更は保存されません。編集をキャンセルしてもよろしいですか?",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -681,6 +681,11 @@
       },
       "passwordMask": "********",
       "resetPassword": "重設密碼",
+      "nameDisplay": "{lastName}{firstName}",
+      "sections": {
+        "personal": "個人資料",
+        "security": "密碼與安全"
+      },
       "confirmCancel": {
         "title": "確定要取消編輯嗎？",
         "description": "取消編輯後，將不會儲存您所做的變更，確定要取消編輯嗎？",


### PR DESCRIPTION
## What changed

### Account page redesign (5234cd3)
- Replaced the oversized centred illustration with an identity header: display name (new `.type-identity` token, documented in DESIGN.md), muted email, and a smaller illustration; attribution moved to a muted caption at the bottom.
- Grouped fields into 個人資料 and 密碼與安全 sections using the existing records-detail section vocabulary (`type-subsection-title` + `border-main-tint02` underline).
- View values now sit in muted pills with the same geometry as the edit inputs, so toggling edit mode changes only the surface with zero layout shift.
- Reset-password button now uses `buttonVariants('main-outline')` instead of a hand-rolled pink pill; removed a manual `gray-* dark:gray-*` pair.
- Sticky title bar is constrained to the same `max-w-2xl` column as the content so the title, underline and actions align with the fields (it previously spanned the full container and looked detached).
- i18n: added `account.profile.nameDisplay` and `sections.{personal,security}` to zh-TW/en/ja; CJK names follow the locale's order, Latin names render as "First Last".

### Bug fixes
- **en pages rendered in Times (site-wide):** next/font variables were mounted on `<body>` while the `:lang()` font-family rules resolve at `<html>`, collapsing the custom-property chain to the browser default. Font variable classes now live on `<html>`.
- **Identity select fallback:** when `profile.title` was not in the option list, the edit-mode select displayed 學生 while the view showed 其他; unknown values are now normalised to `Null`.
- **Records dark mode (8b74b4e):** zebra rows, borders and chart axis/label/tooltip colours were unreadable in dark mode; switched to semantic tokens and `currentColor`.

## Why

The account page was a flat, ungrouped label/value list with a dominant illustration and several design-system violations. This brings it in line with DESIGN.md using only existing tokens and component vocabulary.

## Reviewer notes

- Verified in Chrome: light/dark, 1900/1280/390 px, zh-TW/en/ja, view/edit toggle; `pnpm lint` (3 pre-existing warnings) and `tsc --noEmit` clean.
- `.type-identity` is registered in `globals.css` per the Type-Class Rule and documented in DESIGN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)