### PR TITLE
fix(api): validate records POST input and unify profile creation

### DIFF
--- a/src/app/api/records/[id]/route.ts
+++ b/src/app/api/records/[id]/route.ts
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server';
 import { getRequestLocale } from '@/lib/i18n/request';
 import { localizeRecord } from '@/lib/records';
 import { withAuthContext } from '@/lib/auth-context';
+import { MAX_NARRATIVE_LENGTH } from '@/lib/records-validation';
 
 /**
  * GET /api/records/[id]
@@ -75,6 +76,15 @@ export async function PUT(
 
     const body = await request.json();
     const { story, actions, results, feelings, reaction } = body;
+
+    // Cap free-text length at the trust boundary, same limit as POST.
+    if (
+      [story, actions, results, feelings, reaction].some(
+        (value) => typeof value === 'string' && value.length > MAX_NARRATIVE_LENGTH,
+      )
+    ) {
+      return NextResponse.json({ error: tRecords('fieldTooLong') }, { status: 400 });
+    }
 
     // Only allow updating story-related fields (same as old version)
     const { data: updatedRecord, error: updateError } = await supabase

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -13,6 +13,7 @@ import { buildSearchTokens, resolveMatchingCardIds } from '@/lib/records-search'
 import { withAuthContext } from '@/lib/auth-context';
 import { createAdminClient } from '@/lib/supabase';
 import { buildProfileInsert } from '@/lib/profile-insert';
+import { validateRecordInput, type RecordInput } from '@/lib/records-validation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 import type { SearchEmotionRecordsRow } from '@/types/database';
@@ -40,18 +41,6 @@ async function fetchRecordsByIds(
     .filter((r): r is NonNullable<typeof r> => r != null);
 }
 
-interface RecordInput {
-  cards: number[];
-  beforeLevels?: Record<number, number>;
-  afterLevels?: Record<number, number>;
-  storyBackground?: string;
-  storyAction?: string;
-  storyResult?: string;
-  storyFeeling?: string;
-  storyExpect?: unknown;
-  storyBetterAction?: string;
-}
-
 /** Shape an emotion_records insert row from the request body, shared by both POST paths. */
 function buildRecordRow(input: RecordInput, userId: string) {
   const card1Id = input.cards[0] || null;
@@ -76,63 +65,6 @@ function buildRecordRow(input: RecordInput, userId: string) {
     expect: input.storyExpect !== null && input.storyExpect !== undefined ? String(input.storyExpect) : null,
     reaction: input.storyBetterAction || null,
   };
-}
-
-/** Max length for each free-text narrative field, capped before insert to avoid abuse. */
-const MAX_NARRATIVE_LENGTH = 5000;
-
-const NARRATIVE_FIELDS = [
-  'storyBackground', 'storyAction', 'storyResult',
-  'storyFeeling', 'storyExpect', 'storyBetterAction',
-] as const;
-
-type RecordValidationError = 'invalidCards' | 'invalidLevels' | 'fieldTooLong';
-
-function isValidLevel(value: unknown): boolean {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 10;
-}
-
-/**
- * Validate a POST /api/records body at the trust boundary.
- * Pure function (no request/locale) — returns a translation key on failure.
- */
-function validateRecordInput(
-  body: unknown,
-): { ok: true; input: RecordInput } | { ok: false; key: RecordValidationError } {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return { ok: false, key: 'invalidCards' };
-  }
-  const payload = body as Record<string, unknown>;
-
-  const cards = payload.cards;
-  if (
-    !Array.isArray(cards) || cards.length === 0 || cards.length > 3 ||
-    !cards.every((c) => typeof c === 'number' && Number.isInteger(c))
-  ) {
-    return { ok: false, key: 'invalidCards' };
-  }
-
-  // Levels are optional; when present for a selected card they must be an integer 1–10.
-  const beforeLevels = payload.beforeLevels as Record<number, unknown> | undefined;
-  const afterLevels = payload.afterLevels as Record<number, unknown> | undefined;
-  for (const cardId of cards) {
-    for (const levels of [beforeLevels, afterLevels]) {
-      const value = levels?.[cardId];
-      if (value !== undefined && value !== null && !isValidLevel(value)) {
-        return { ok: false, key: 'invalidLevels' };
-      }
-    }
-  }
-
-  // Cap free-text length.
-  for (const field of NARRATIVE_FIELDS) {
-    const value = payload[field];
-    if (value !== undefined && value !== null && String(value).length > MAX_NARRATIVE_LENGTH) {
-      return { ok: false, key: 'fieldTooLong' };
-    }
-  }
-
-  return { ok: true, input: payload as unknown as RecordInput };
 }
 
 /**

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -12,6 +12,7 @@ import {
 import { buildSearchTokens, resolveMatchingCardIds } from '@/lib/records-search';
 import { withAuthContext } from '@/lib/auth-context';
 import { createAdminClient } from '@/lib/supabase';
+import { buildProfileInsert } from '@/lib/profile-insert';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 import type { SearchEmotionRecordsRow } from '@/types/database';
@@ -75,6 +76,63 @@ function buildRecordRow(input: RecordInput, userId: string) {
     expect: input.storyExpect !== null && input.storyExpect !== undefined ? String(input.storyExpect) : null,
     reaction: input.storyBetterAction || null,
   };
+}
+
+/** Max length for each free-text narrative field, capped before insert to avoid abuse. */
+const MAX_NARRATIVE_LENGTH = 5000;
+
+const NARRATIVE_FIELDS = [
+  'storyBackground', 'storyAction', 'storyResult',
+  'storyFeeling', 'storyExpect', 'storyBetterAction',
+] as const;
+
+type RecordValidationError = 'invalidCards' | 'invalidLevels' | 'fieldTooLong';
+
+function isValidLevel(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 10;
+}
+
+/**
+ * Validate a POST /api/records body at the trust boundary.
+ * Pure function (no request/locale) — returns a translation key on failure.
+ */
+function validateRecordInput(
+  body: unknown,
+): { ok: true; input: RecordInput } | { ok: false; key: RecordValidationError } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, key: 'invalidCards' };
+  }
+  const payload = body as Record<string, unknown>;
+
+  const cards = payload.cards;
+  if (
+    !Array.isArray(cards) || cards.length === 0 || cards.length > 3 ||
+    !cards.every((c) => typeof c === 'number' && Number.isInteger(c))
+  ) {
+    return { ok: false, key: 'invalidCards' };
+  }
+
+  // Levels are optional; when present for a selected card they must be an integer 1–10.
+  const beforeLevels = payload.beforeLevels as Record<number, unknown> | undefined;
+  const afterLevels = payload.afterLevels as Record<number, unknown> | undefined;
+  for (const cardId of cards) {
+    for (const levels of [beforeLevels, afterLevels]) {
+      const value = levels?.[cardId];
+      if (value !== undefined && value !== null && !isValidLevel(value)) {
+        return { ok: false, key: 'invalidLevels' };
+      }
+    }
+  }
+
+  // Cap free-text length.
+  for (const field of NARRATIVE_FIELDS) {
+    const value = payload[field];
+    if (value !== undefined && value !== null && String(value).length > MAX_NARRATIVE_LENGTH) {
+      return { ok: false, key: 'fieldTooLong' };
+    }
+  }
+
+  return { ok: true, input: payload as unknown as RecordInput };
 }
 
 /**
@@ -190,20 +248,14 @@ export async function POST(request: NextRequest) {
       }
 
       const body = await request.json();
-      const { cards } = body;
-
-      if (!cards || !Array.isArray(cards) || cards.length === 0 || cards.length > 3) {
-        return NextResponse.json({ error: tRecords('invalidCards') }, { status: 400 });
+      const validation = validateRecordInput(body);
+      if (!validation.ok) {
+        return NextResponse.json({ error: tRecords(validation.key) }, { status: 400 });
       }
 
       const { data: newProfile, error: createError } = await adminClient
         .from('profiles')
-        .insert({
-          workos_user_id: user.id,
-          email: user.email,
-          first_name: user.firstName || null,
-          last_name: user.lastName || null,
-        })
+        .insert(buildProfileInsert(user))
         .select('id')
         .single();
 
@@ -214,7 +266,7 @@ export async function POST(request: NextRequest) {
 
       const { error: insertError } = await adminClient
         .from('emotion_records')
-        .insert(buildRecordRow(body, newProfile.id));
+        .insert(buildRecordRow(validation.input, newProfile.id));
 
       if (insertError) {
         console.error('Error inserting emotion record:', insertError);
@@ -232,15 +284,14 @@ export async function POST(request: NextRequest) {
     const tRecords = await getTranslations({ locale, namespace: 'apiErrors.records' });
 
     const body = await request.json();
-    const { cards } = body;
-
-    if (!cards || !Array.isArray(cards) || cards.length === 0 || cards.length > 3) {
-      return NextResponse.json({ error: tRecords('invalidCards') }, { status: 400 });
+    const validation = validateRecordInput(body);
+    if (!validation.ok) {
+      return NextResponse.json({ error: tRecords(validation.key) }, { status: 400 });
     }
 
     const { error: insertError } = await supabase
       .from('emotion_records')
-      .insert(buildRecordRow(body, profileId));
+      .insert(buildRecordRow(validation.input, profileId));
 
     if (insertError) {
       console.error('Error inserting emotion record:', insertError);

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -8,6 +8,7 @@ import {
 import { getRequestLocale } from '@/lib/i18n/request';
 import { withAuthContext } from '@/lib/auth-context';
 import { createAdminClient } from '@/lib/supabase';
+import { buildProfileInsert } from '@/lib/profile-insert';
 import type { Database } from '@/types/database';
 
 type LocalePreference = 'zh-TW' | 'en' | 'ja';
@@ -54,13 +55,7 @@ export async function GET() {
 
         const { data: newProfile, error: insertError } = await adminClient
           .from('profiles')
-          .insert({
-            workos_user_id: user.id,
-            email: user.email,
-            locale_preference: 'zh-TW',
-            first_name: user.firstName || null,
-            last_name: user.lastName || null,
-          })
+          .insert(buildProfileInsert(user))
           .select()
           .single();
 

--- a/src/lib/profile-insert.ts
+++ b/src/lib/profile-insert.ts
@@ -1,0 +1,21 @@
+import type { ProfileInsert } from "@/types/database";
+
+/**
+ * Build a profiles insert row for a WorkOS user.
+ * Single source of truth so every profile-creation path writes the same field set.
+ * Lives outside profile.ts because that module is "use server" (exports must be async).
+ */
+export function buildProfileInsert(user: {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+}): ProfileInsert {
+  return {
+    workos_user_id: user.id,
+    email: user.email,
+    locale_preference: "zh-TW",
+    first_name: user.firstName,
+    last_name: user.lastName,
+  };
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from "@/lib/supabase";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { withAuthContext } from "@/lib/auth-context";
+import { buildProfileInsert } from "@/lib/profile-insert";
 import type {
   LocalePreference,
   Profile,
@@ -70,12 +71,7 @@ export async function syncUserProfile(): Promise<UserProfile | null> {
   // Create new profile for first-time users
   const { data: newProfile, error: insertError } = await supabase
     .from("profiles")
-    .insert({
-      workos_user_id: user.id,
-      email: user.email,
-      first_name: user.firstName,
-      last_name: user.lastName,
-    })
+    .insert(buildProfileInsert(user))
     .select()
     .single();
 

--- a/src/lib/records-validation.ts
+++ b/src/lib/records-validation.ts
@@ -1,0 +1,68 @@
+/** Max length for each free-text narrative field, capped before insert/update to avoid abuse. */
+export const MAX_NARRATIVE_LENGTH = 5000;
+
+export interface RecordInput {
+  cards: number[];
+  beforeLevels?: Record<number, number>;
+  afterLevels?: Record<number, number>;
+  storyBackground?: string;
+  storyAction?: string;
+  storyResult?: string;
+  storyFeeling?: string;
+  storyExpect?: unknown;
+  storyBetterAction?: string;
+}
+
+export type RecordValidationError = 'invalidCards' | 'invalidLevels' | 'fieldTooLong';
+
+const NARRATIVE_FIELDS = [
+  'storyBackground', 'storyAction', 'storyResult',
+  'storyFeeling', 'storyExpect', 'storyBetterAction',
+] as const;
+
+function isValidLevel(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 10;
+}
+
+/**
+ * Validate a POST /api/records body at the trust boundary.
+ * Pure function (no request/locale) — returns a translation key on failure.
+ */
+export function validateRecordInput(
+  body: unknown,
+): { ok: true; input: RecordInput } | { ok: false; key: RecordValidationError } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, key: 'invalidCards' };
+  }
+  const payload = body as Record<string, unknown>;
+
+  const cards = payload.cards;
+  if (
+    !Array.isArray(cards) || cards.length === 0 || cards.length > 3 ||
+    !cards.every((c) => typeof c === 'number' && Number.isInteger(c))
+  ) {
+    return { ok: false, key: 'invalidCards' };
+  }
+
+  // Levels are optional; when present for a selected card they must be an integer 1–10.
+  const beforeLevels = payload.beforeLevels as Record<number, unknown> | undefined;
+  const afterLevels = payload.afterLevels as Record<number, unknown> | undefined;
+  for (const cardId of cards) {
+    for (const levels of [beforeLevels, afterLevels]) {
+      const value = levels?.[cardId];
+      if (value !== undefined && value !== null && !isValidLevel(value)) {
+        return { ok: false, key: 'invalidLevels' };
+      }
+    }
+  }
+
+  // Cap free-text length.
+  for (const field of NARRATIVE_FIELDS) {
+    const value = payload[field];
+    if (value !== undefined && value !== null && String(value).length > MAX_NARRATIVE_LENGTH) {
+      return { ok: false, key: 'fieldTooLong' };
+    }
+  }
+
+  return { ok: true, input: payload as unknown as RecordInput };
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -804,7 +804,9 @@
       "updateFailed": "Failed to update record",
       "deleteFailed": "Failed to delete record",
       "invalidCards": "Cards must be an array containing 1 to 3 cards",
-      "profileCreateFailed": "Failed to create profile"
+      "profileCreateFailed": "Failed to create profile",
+      "invalidLevels": "Emotion levels must be integers between 1 and 10",
+      "fieldTooLong": "Text content exceeds the maximum length"
     },
     "analysis": {
       "missingDateRange": "Both start date and end date are required",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -804,7 +804,9 @@
       "updateFailed": "レコードの更新に失敗しました",
       "deleteFailed": "レコードの削除に失敗しました",
       "invalidCards": "カードは 1 枚から 3 枚までの配列である必要があります",
-      "profileCreateFailed": "プロフィールの作成に失敗しました"
+      "profileCreateFailed": "プロフィールの作成に失敗しました",
+      "invalidLevels": "感情の強さは 1 から 10 の整数である必要があります",
+      "fieldTooLong": "テキストが最大文字数を超えています"
     },
     "analysis": {
       "missingDateRange": "開始日と終了日を指定してください",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -804,7 +804,9 @@
       "updateFailed": "更新紀錄失敗",
       "deleteFailed": "刪除紀錄失敗",
       "invalidCards": "卡片必須是 1 到 3 張的陣列",
-      "profileCreateFailed": "建立使用者資料失敗"
+      "profileCreateFailed": "建立使用者資料失敗",
+      "invalidLevels": "情緒強度必須是 1 到 10 的整數",
+      "fieldTooLong": "文字內容超過長度上限"
     },
     "analysis": {
       "missingDateRange": "必須提供開始與結束日期",


### PR DESCRIPTION
## What

Tech-debt **Phase 2** — correctness hardening on the records API.

### #3 Input validation at the trust boundary (main)
Both write paths now cap free-text length at **5000 chars** (`MAX_NARRATIVE_LENGTH`):

- **`POST /api/records`** — new pure `validateRecordInput()`: cards (array, 1–3, integers), before/after levels (integer 1–10 when present), and the narrative-field length cap.
- **`PUT /api/records/[id]`** — rejects oversized `story/actions/results/feelings/reaction` with a 400 (added after review — see below).
- Validator + cap live in `src/lib/records-validation.ts` (single source of truth, pure/testable for Phase 3).
- New `apiErrors.records` keys in all three locales: `invalidLevels`, `fieldTooLong`.

### #2 Profile-creation DRY
New `buildProfileInsert(user)` as the single source of truth for the `profiles` insert field set, shared by the records POST 404 branch, the user GET 404 branch, and `syncUserProfile`.

## Why

- `CLAUDE.md`'s "API input validation" section mandates range-checking numeric inputs and capping free-text length; the records routes were not following it (`api/user` PUT is the reference). The unbounded `TEXT` narrative columns were the one genuinely unguarded vector — a large payload could bloat rows and the `search_vector`. **Both POST and PUT are now guarded**, so that hole is fully closed.
- Out-of-range levels were already caught by the DB `CHECK (... BETWEEN 1 AND 10)`, but surfaced as an ugly 500. POST now returns a clean **400**.
- The three profile-insert sites had drifted apart; consolidating prevents future divergence (consistent with the Phase 1 `buildRecordRow` extraction).

## Reviewer notes

- **#2 is not a bug fix.** `profiles.locale_preference` has a DB default of `'zh-TW'` (migration `20260322`), so the prior missing-field on the records path was cosmetic, not data loss.
- `buildProfileInsert` lives in a separate `profile-insert.ts` rather than `profile.ts` because the latter is `"use server"` (all exports must be async server actions).
- `validateRecordInput` is a **pure function** (no request/locale) so Phase 3 can unit-test it directly once vitest lands.

## Verification

- ✅ `pnpm lint` clean
- ✅ `pnpm build` (type-check) passes
- ⚠️ Authed end-to-end POST/PUT not exercised (requires a WorkOS session); boundary cases (0/1/10/11, oversized text, cards length) to be covered by Phase 3 unit tests against `records-validation.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)